### PR TITLE
refactor:  axios + nprogress 연동으로 변경

### DIFF
--- a/src/app/Sheet.tsx
+++ b/src/app/Sheet.tsx
@@ -1,8 +1,8 @@
 import React, { useLayoutEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 import { css } from '@emotion/react'
-import { useIsFetching, useIsMutating } from 'react-query'
-import { useNProgress } from '@/hooks'
+// import { useIsFetching, useIsMutating } from 'react-query'
+// import { useNProgress } from '@/hooks'
 
 const SheetCss = css`
   position: relative;
@@ -19,10 +19,10 @@ const SheetCss = css`
 const Sheet: React.FC = ({ children }) => {
   const location = useLocation()
 
-  const isFetching = useIsFetching() // 1(true) or 0(false)
-  const isMutating = useIsMutating() // 1(true) or 0(false)
+  // const isFetching = useIsFetching() // 1(true) or 0(false)
+  // const isMutating = useIsMutating() // 1(true) or 0(false)
 
-  useNProgress([location.pathname, isFetching, isMutating])
+  // useNProgress([location.pathname])
 
   useLayoutEffect(() => {
     const scrollY = sessionStorage.getItem('scrollY')

--- a/src/common/Frame.tsx
+++ b/src/common/Frame.tsx
@@ -24,7 +24,7 @@ const LastChild = styled.div`
 const _Frame: React.FC<Props> = ({ isLoading = false, onIntersect = () => null, children }) => {
   const targetRef = useIntersectionObserver<HTMLDivElement>(onIntersect)
 
-  useNProgress([isLoading])
+  // useNProgress([isLoading])
 
   return (
     <Frame>

--- a/src/features/foods/hooks/index.ts
+++ b/src/features/foods/hooks/index.ts
@@ -1,27 +1,21 @@
 import { useQuery } from 'react-query'
+import { AxiosError } from 'axios'
 import foodService from '../service'
+import type { Food, FoodDetail } from '../service/food'
 
 export function useFoodList() {
-  return useQuery('foods', foodService.getFoods)
+  return useQuery<Food[], AxiosError>('foods', foodService.getFoods)
 }
 
 export function useFoodDetails() {
-  return useQuery('foodDetails', foodService.getFoodDetails)
+  return useQuery<FoodDetail[], AxiosError>('foodDetails', foodService.getFoodDetails)
 }
 
 export function useFoodDetailById(id: number) {
-  const { data, isLoading, isError } = useFoodDetails()
+  const { data } = useFoodDetails()
   if (data) {
     const foodDetail = data.find((item) => item.id === id) || null
-    return {
-      data: foodDetail,
-      isLoading,
-      isError,
-    }
+    return { data: foodDetail }
   }
-  return {
-    data: null,
-    isLoading,
-    isError,
-  }
+  return { data: null }
 }

--- a/src/features/foods/service/index.ts
+++ b/src/features/foods/service/index.ts
@@ -1,29 +1,5 @@
-import axios from 'axios'
-import nprogress from 'nprogress'
+import axios from '@/service/axios'
 import type { Food, FoodDetail } from './food'
-
-nprogress.configure({ showSpinner: false, speed: 500 })
-
-axios.defaults.onDownloadProgress = (e: ProgressEvent) => {
-  const percentage = Math.floor(e.loaded * 1.0) / e.total
-  nprogress.set(percentage)
-}
-
-axios.defaults.onUploadProgress = (e: ProgressEvent) => {
-  const percentage = Math.floor(e.loaded * 1.0) / e.total
-  nprogress.set(percentage)
-}
-
-axios.interceptors.response.use(
-  (response) => {
-    nprogress.done()
-    return response
-  },
-  (error) => {
-    nprogress.done()
-    return Promise.reject(error)
-  },
-)
 
 const foodAPI = axios.create({
   baseURL: 'http://localhost:8080/',

--- a/src/features/foods/service/index.ts
+++ b/src/features/foods/service/index.ts
@@ -1,5 +1,29 @@
 import axios from 'axios'
+import nprogress from 'nprogress'
 import type { Food, FoodDetail } from './food'
+
+nprogress.configure({ showSpinner: false, speed: 500 })
+
+axios.defaults.onDownloadProgress = (e: ProgressEvent) => {
+  const percentage = Math.floor(e.loaded * 1.0) / e.total
+  nprogress.set(percentage)
+}
+
+axios.defaults.onUploadProgress = (e: ProgressEvent) => {
+  const percentage = Math.floor(e.loaded * 1.0) / e.total
+  nprogress.set(percentage)
+}
+
+axios.interceptors.response.use(
+  (response) => {
+    nprogress.done()
+    return response
+  },
+  (error) => {
+    nprogress.done()
+    return Promise.reject(error)
+  },
+)
 
 const foodAPI = axios.create({
   baseURL: 'https://nrisecodingtest.s3.ap-northeast-2.amazonaws.com/fe/food',
@@ -8,7 +32,6 @@ const foodAPI = axios.create({
 
 const foodService = {
   getFoods: async () => {
-    // 에러 캐치와 함께 에러 바운더리로 버블링
     const { data } = await foodAPI.get<Food[]>('/food_main_list.json')
     return data
   },

--- a/src/hooks/useNProgress.ts
+++ b/src/hooks/useNProgress.ts
@@ -1,12 +1,13 @@
 import React, { useLayoutEffect } from 'react'
 import nprogress from 'nprogress'
 
+nprogress.configure({ showSpinner: false, speed: 500 })
+
 const useNProgress = (deps: React.DependencyList) => {
   useLayoutEffect(() => {
     if (nprogress.isStarted()) {
       nprogress.done()
     } else {
-      nprogress.configure({ showSpinner: false, speed: 500 })
       nprogress.start()
       nprogress.done()
     }

--- a/src/service/axios.ts
+++ b/src/service/axios.ts
@@ -1,0 +1,27 @@
+import axios from 'axios'
+import nprogress from 'nprogress'
+
+nprogress.configure({ showSpinner: false, speed: 500 })
+
+axios.defaults.onDownloadProgress = (e: ProgressEvent) => {
+  const percentage = Math.floor(e.loaded * 1.0) / e.total
+  nprogress.set(percentage)
+}
+
+axios.defaults.onUploadProgress = (e: ProgressEvent) => {
+  const percentage = Math.floor(e.loaded * 1.0) / e.total
+  nprogress.set(percentage)
+}
+
+axios.interceptors.response.use(
+  (response) => {
+    nprogress.done()
+    return response
+  },
+  (error) => {
+    nprogress.done()
+    return Promise.reject(error)
+  },
+)
+
+export default axios


### PR DESCRIPTION
#### AS-IS
현재 개발된 react-query + nprogress 방식은 전역 react-query의 `Provider(QueryClient)`의 현재 진행 중인 API 요청에 대한 상태를 사용하는 내장  `isFetching`, `isMutating` 상태를 감시해 Progress UI를 활성화하고 있으나, API 요청 및 응답에 대한 진척도(%)에 대한 데이터와 상관 없이 on/off 방식으로 애니메이션이 진행되고 있음

#### TO-BE
- axios의 `onDownloadProgress`, `onUploadProgress` 이벤트와 nprogress를 연동하여 정확한 진척도를 UI를 통해 출력
- 공통 axios 생성자 모듈을 만들어 공통 디렉토리에서 호출해서 feature별 인스턴스를 생성해 사용할 수 있게 디렉토리 구조 변경